### PR TITLE
Fixes issues with lib name generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-/blib
 /Makefile
 /linenoise.o
 /lib/Linenoise.pm
 /constant-helper
 /resources/
 .precomp
+/lib/.precomp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: perl6
 install:
-  - rakudobrew build-panda
+  - rakudobrew build zef
 before_script:
-  - panda installdeps .
-  - panda-build
-
+  - zef --depsonly install .
+  - zef --debug install .
 script:
-  - PERL6LIB=lib perl6 -MLinenoise -e 1
+  - perl6 -MLinenoise -e 1

--- a/Build.pm
+++ b/Build.pm
@@ -1,18 +1,12 @@
 use v6;
-
-use Panda::Builder;
 use LibraryMake;
-use Shell::Command;
 
-class Build is Panda::Builder {
-    method build($workdir) {
-        mkdir("$workdir/blib");
-        mkdir("$workdir/blib/lib");
-        my %vars = get-vars("$workdir/blib/lib");
-
-        %vars<helper> = 'resources/libraries/' ~ $*VM.platform-library-name('liblinenoise'.IO);
-
-        process-makefile($workdir, %vars);
-        shell(%vars<MAKE>);
+class Build {
+    method build($srcdir) {
+        my %vars = get-vars($srcdir);
+        %vars<linenoise> = $*VM.platform-library-name('linenoise'.IO).basename;
+        mkdir "$srcdir/resources/libraries" unless "$srcdir/resources/libraries".IO.e;
+        process-makefile($srcdir, %vars);
+        shell %vars<MAKE>, :cwd($srcdir);
     }
 }

--- a/META6.json
+++ b/META6.json
@@ -1,13 +1,14 @@
 {
     "perl" : "6.*",
     "name" : "Linenoise",
-    "version" : "0.1.0",
+    "version" : "0.1.1",
     "description" : "Bindings to linenoise",
     "author" : "Rob Hoelz",
-    "depends" : ["LibraryMake", "Shell::Command"],
+    "depends" : [ ],
+    "build-depends" : ["LibraryMake"],
     "source-url" : "https://github.com/hoelzro/p6-linenoise.git",
     "provides": {
-        "Linenoise": "lib/Linenoise.pm"
+        "Linenoise": "lib/Linenoise.pm6"
     },
     "resources": [
         "libraries/linenoise"

--- a/Makefile.in
+++ b/Makefile.in
@@ -1,14 +1,18 @@
-all: %helper% lib/Linenoise.pm
+name = %linenoise%
 
-%helper%: linenoise%O%
+all: %DESTDIR%/resources/libraries/%linenoise% lib/Linenoise.pm6
+clean:
+	rm %DESTDIR%/resources/libraries/%linenoise%
+
+%DESTDIR%/resources/libraries/%linenoise%: linenoise%O%
 	perl6 -e "mkdir 'resources'; mkdir 'resources/libraries'"
-	%LD% %LDSHARED% %LDFLAGS% %LIBS% %LDOUT%resources/libraries/liblinenoise%SO% linenoise%O%
+	%LD% %LDSHARED% %LDFLAGS% %LIBS% %LDOUT%resources/libraries/%linenoise% linenoise%O%
 
 linenoise%O%: linenoise.c
-	%CC% -c %CCSHARED% %CCFLAGS% %CCOUT%linenoise%O% linenoise.c
+	%CC% -c %CCSHARED% %CCFLAGS% %CCOUT% linenoise%O% linenoise.c
 
 constant-helper: constant-helper.c
 	%CC% %CCOUT%constant-helper %CCFLAGS% constant-helper.c
 
-lib/Linenoise.pm: lib/Linenoise.pm.in constant-helper
-	perl6 fill-constants.pl < lib/Linenoise.pm.in > lib/Linenoise.pm
+lib/Linenoise.pm6: lib/Linenoise.pm6.in constant-helper
+	perl6 fill-constants.pl < lib/Linenoise.pm6.in > lib/Linenoise.pm6

--- a/lib/Linenoise.pm6.in
+++ b/lib/Linenoise.pm6.in
@@ -5,7 +5,7 @@ use NativeCall;
 #| This module provides bindings to linenoise
 #| (L<https://github.com/antirez/linenoise>) for Perl 6
 #| via NativeCall.
-module Linenoise:ver<0.1.0>:auth<github:hoelzro> {
+module Linenoise:ver<0.1.1>:auth<github:hoelzro> {
     my constant STDIN_FILENO = 0;
     my constant F_GETFL      = #`(FILL-ME-IN);
     my constant F_SETFL      = #`(FILL-ME-IN);


### PR DESCRIPTION
This fixes a problem where automatic library name generation is
used, but part of the generated library name is hardcoded else-
where. This resulted in the build failing on windows, because
the hardcoded portion was not applicapable.

Note that while this allows Linenoise to be installed on windows
once again, it still does not work properly. This is because libs
that get installed have their file names mangled, but I think the
linenoise.dll file needs to have the same name? (some missing
symbol error gets thrown). OpenSSL had this problem, which it works
around with lib/OpenSSL/NativeLib.pm6